### PR TITLE
feat: Add command to install local documentation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,9 @@ include README.md
 include README.pt.md
 include requirements.txt
 recursive-include docs *.md
+recursive-include docs *.html
+recursive-include docs *.css
+recursive-include docs *.js
+recursive-include docs *.png
+recursive-include docs *.jpg
+recursive-include docs *.svg

--- a/docs/en/development_guide.md
+++ b/docs/en/development_guide.md
@@ -213,11 +213,162 @@ pre-commit run --all-files
       └── test_aws_setup.py
   ```
 
-### Documentation
+# Documentation
 
-- Keep documentation up-to-date with code changes
-- Document new parameters in functions and behavior changes
-- Add usage examples for new features
+## Documentation Packaging and Access
+
+The MicroDetect project now includes a comprehensive documentation system that is properly packaged with the distribution. This section explains how the documentation is structured, packaged, and served.
+
+## Documentation Structure
+
+The documentation is organized in a language-based structure:
+
+```
+docs/
+├── en/                          # English documentation
+│   ├── index.md                 # Main entry point
+│   ├── installation_guide.md    # Installation instructions
+│   ├── ...                      # Other topic files
+└── pt/                          # Portuguese documentation
+    ├── index.md                 # Main entry point (Portuguese)
+    ├── installation_guide.md    # Installation instructions (Portuguese)
+    └── ...                      # Other topic files
+```
+
+## Documentation Packaging
+
+The documentation is included in the MicroDetect package during the build process using two mechanisms:
+
+### 1. MANIFEST.in Configuration
+
+The `MANIFEST.in` file includes the following directives to include documentation files:
+
+```
+recursive-include docs *.md
+recursive-include docs *.html
+recursive-include docs *.css
+recursive-include docs *.js
+recursive-include docs *.png
+recursive-include docs *.jpg
+recursive-include docs *.svg
+```
+
+### 2. setup.py Configuration
+
+The `setup.py` file includes code to collect and organize documentation files:
+
+```python
+# Collect all documentation files
+doc_files = glob.glob('docs/**/*.md', recursive=True)
+doc_files += glob.glob('docs/**/*.html', recursive=True)
+doc_files += glob.glob('docs/**/*.css', recursive=True)
+# ...etc.
+
+# Organize doc files by directory structure
+doc_dirs = {}
+for doc_file in doc_files:
+    rel_dir = os.path.dirname(doc_file)
+    if rel_dir not in doc_dirs:
+        doc_dirs[rel_dir] = []
+    doc_dirs[rel_dir].append(doc_file)
+
+# Create data_files entries for each directory
+doc_data_files = []
+for rel_dir, files in doc_dirs.items():
+    install_dir = os.path.join('share/microdetect', rel_dir)
+    doc_data_files.append((install_dir, files))
+
+# Add to setup
+setup(
+    # ...other setup parameters...
+    data_files=doc_data_files,
+)
+```
+
+This ensures that documentation files are properly installed in the `share/microdetect/docs/` directory of the Python package.
+
+## Documentation Server
+
+The MicroDetect CLI includes a built-in documentation server:
+
+```python
+# In microdetect/utils/docs_server.py
+```
+
+This module provides:
+
+1. A web server that renders Markdown files as HTML
+2. A navigation sidebar with organized documentation links
+3. Language switching between English and Portuguese
+4. Search functionality
+5. The ability to run in background mode
+
+## CLI Commands for Documentation
+
+Two main commands have been implemented for documentation access:
+
+### 1. `microdetect docs`
+
+Starts the documentation server:
+
+```bash
+# Basic usage
+microdetect docs
+
+# Language options
+microdetect docs --lang pt  # Portuguese
+microdetect docs --lang en  # English (default)
+
+# Background mode
+microdetect docs --background
+microdetect docs --status
+microdetect docs --stop
+```
+
+### 2. `microdetect install-docs`
+
+Installs documentation files to the user's home directory:
+
+```bash
+microdetect install-docs [--force]
+```
+
+This copies documentation files to `~/.microdetect/docs/` for offline access.
+
+## Development Workflow for Documentation
+
+When developing or updating documentation:
+
+1. Edit the appropriate Markdown files in the `docs/` directory
+2. Test the documentation locally using `microdetect docs`
+3. Make sure to update both language versions as needed
+4. Documentation changes will be included in the next package build
+
+## Best Practices for Documentation
+
+1. Keep documentation in sync across languages
+2. Use relative links between documentation files for navigation
+3. Prefix internal documentation links with language information
+4. Use a consistent structure across language versions
+5. Include code examples and screenshots when appropriate
+6. Remember to update documentation when making significant code changes
+
+## Testing Documentation Packaging
+
+To test that documentation is correctly packaged:
+
+```bash
+# Build the package
+python setup.py sdist bdist_wheel
+
+# Install the package in a test environment
+pip install --force-reinstall dist/microdetect-*.whl
+
+# Start the documentation server to verify installation
+microdetect docs
+```
+
+This will verify that documentation files are properly included in the build and can be accessed through the documentation server.
 
 ## Development Workflow
 

--- a/docs/en/installation_guide.md
+++ b/docs/en/installation_guide.md
@@ -231,6 +231,91 @@ cd my_project
 microdetect init
 ```
 
+## Accessing Documentation
+
+MicroDetect now includes comprehensive documentation that's packaged with the software. Here's how to access it:
+
+## Using the Documentation Server
+
+The easiest way to view the documentation is through the built-in documentation server:
+
+```bash
+# Start the documentation server
+microdetect docs
+
+# Start with a specific language
+microdetect docs --lang pt  # For Portuguese documentation
+microdetect docs --lang en  # For English documentation (default)
+
+# Use a different port
+microdetect docs --port 8888
+```
+
+This command will start a local web server and automatically open your browser to display the documentation.
+
+### Running in Background
+
+You can also run the documentation server in the background:
+
+```bash
+# Start the server in background
+microdetect docs --background
+
+# Check server status
+microdetect docs --status
+
+# Stop the server
+microdetect docs --stop
+```
+
+## Installing Documentation Locally
+
+If you prefer to have the documentation installed in your user directory:
+
+```bash
+# Install documentation files to ~/.microdetect/docs
+microdetect install-docs
+
+# Force reinstallation if files already exist
+microdetect install-docs --force
+```
+
+This makes the documentation available even when offline and ensures that it's accessible through the `microdetect docs` command.
+
+## Accessing Documentation Files Directly
+
+Documentation files are included in the MicroDetect package and are installed in the following locations:
+
+1. Package directory: `<python_site_packages>/share/microdetect/docs/`
+2. User directory (if installed): `~/.microdetect/docs/`
+
+You can access the raw markdown files directly at these locations if needed.
+
+## Documentation Structure
+
+The documentation is organized by language and topic:
+
+```
+docs/
+├── en/                          # English documentation
+│   ├── index.md                 # Main entry point
+│   ├── installation_guide.md    # Installation instructions
+│   ├── ...                      # Other topics
+└── pt/                          # Portuguese documentation
+    ├── index.md                 # Main entry point (Portuguese)
+    ├── installation_guide.md    # Installation instructions (Portuguese)
+    └── ...                      # Other topics
+```
+
+## Documentation Requirements
+
+The documentation server requires the following packages:
+
+- `markdown`: For converting markdown to HTML
+- `pygments`: For syntax highlighting in code blocks
+
+These will be installed automatically if you use the `microdetect docs` command and choose to install the dependencies when prompted.
+
 ## Configure Update System
 
 After installation, configure the automatic update system:

--- a/docs/en/update_system.md
+++ b/docs/en/update_system.md
@@ -125,11 +125,18 @@ The update system operates as follows:
    - Uses pip to list available versions
    - Extracts and compares versions using semantic versioning
 
-3. **Update**:
+3. **Configuration Sources**:
+   - Looks for AWS credentials in multiple locations in this order:
+     1. Environment variables (`AWS_CODEARTIFACT_DOMAIN`, `AWS_CODEARTIFACT_REPOSITORY`, `AWS_CODEARTIFACT_OWNER`)
+     2. Configuration file at `~/.microdetect/config.ini`
+     3. Local `.env` file (for compatibility)
+
+4. **Update Process**:
    - Sets up pip environment to use AWS CodeArtifact repository
    - Runs the update preserving dependencies
+   - Detects if running in a Conda environment and adjusts accordingly
 
-4. **Check Caching**:
+5. **Check Caching**:
    - Stores the last check date to avoid overloading
    - Checks only once per day (configurable)
 

--- a/docs/pt/development_guide.md
+++ b/docs/pt/development_guide.md
@@ -213,11 +213,162 @@ pre-commit run --all-files
       └── test_aws_setup.py
   ```
 
-### Documentação
+# Documentação
 
-- Mantenha a documentação atualizada com as alterações de código
-- Documente novos parâmetros em funções e alterações de comportamento
-- Adicione exemplos de uso para novas funcionalidades
+## Empacotamento e Acesso à Documentação
+
+O projeto MicroDetect agora inclui um sistema de documentação abrangente que é devidamente empacotado com a distribuição. Esta seção explica como a documentação é estruturada, empacotada e servida.
+
+## Estrutura da Documentação
+
+A documentação está organizada em uma estrutura baseada em idiomas:
+
+```
+docs/
+├── en/                          # Documentação em inglês
+│   ├── index.md                 # Ponto de entrada principal
+│   ├── installation_guide.md    # Instruções de instalação
+│   ├── ...                      # Outros arquivos de tópicos
+└── pt/                          # Documentação em português
+    ├── index.md                 # Ponto de entrada principal (português)
+    ├── installation_guide.md    # Instruções de instalação (português)
+    └── ...                      # Outros arquivos de tópicos
+```
+
+## Empacotamento da Documentação
+
+A documentação é incluída no pacote MicroDetect durante o processo de build usando dois mecanismos:
+
+### 1. Configuração MANIFEST.in
+
+O arquivo `MANIFEST.in` inclui as seguintes diretivas para incluir arquivos de documentação:
+
+```
+recursive-include docs *.md
+recursive-include docs *.html
+recursive-include docs *.css
+recursive-include docs *.js
+recursive-include docs *.png
+recursive-include docs *.jpg
+recursive-include docs *.svg
+```
+
+### 2. Configuração setup.py
+
+O arquivo `setup.py` inclui código para coletar e organizar arquivos de documentação:
+
+```python
+# Coletar todos os arquivos de documentação
+doc_files = glob.glob('docs/**/*.md', recursive=True)
+doc_files += glob.glob('docs/**/*.html', recursive=True)
+doc_files += glob.glob('docs/**/*.css', recursive=True)
+# ...etc.
+
+# Organizar arquivos de documentação por estrutura de diretórios
+doc_dirs = {}
+for doc_file in doc_files:
+    rel_dir = os.path.dirname(doc_file)
+    if rel_dir not in doc_dirs:
+        doc_dirs[rel_dir] = []
+    doc_dirs[rel_dir].append(doc_file)
+
+# Criar entradas data_files para cada diretório
+doc_data_files = []
+for rel_dir, files in doc_dirs.items():
+    install_dir = os.path.join('share/microdetect', rel_dir)
+    doc_data_files.append((install_dir, files))
+
+# Adicionar ao setup
+setup(
+    # ...outros parâmetros de setup...
+    data_files=doc_data_files,
+)
+```
+
+Isso garante que os arquivos de documentação sejam instalados corretamente no diretório `share/microdetect/docs/` do pacote Python.
+
+## Servidor de Documentação
+
+A CLI do MicroDetect inclui um servidor de documentação integrado:
+
+```python
+# Em microdetect/utils/docs_server.py
+```
+
+Este módulo fornece:
+
+1. Um servidor web que renderiza arquivos Markdown como HTML
+2. Uma barra lateral de navegação com links de documentação organizados
+3. Alternância de idioma entre inglês e português
+4. Funcionalidade de busca
+5. A capacidade de executar em modo de segundo plano
+
+## Comandos CLI para Documentação
+
+Dois comandos principais foram implementados para acesso à documentação:
+
+### 1. `microdetect docs`
+
+Inicia o servidor de documentação:
+
+```bash
+# Uso básico
+microdetect docs
+
+# Opções de idioma
+microdetect docs --lang pt  # Português
+microdetect docs --lang en  # Inglês (padrão)
+
+# Modo de segundo plano
+microdetect docs --background
+microdetect docs --status
+microdetect docs --stop
+```
+
+### 2. `microdetect install-docs`
+
+Instala arquivos de documentação no diretório do usuário:
+
+```bash
+microdetect install-docs [--force]
+```
+
+Isso copia os arquivos de documentação para `~/.microdetect/docs/` para acesso offline.
+
+## Fluxo de Trabalho de Desenvolvimento para Documentação
+
+Ao desenvolver ou atualizar a documentação:
+
+1. Edite os arquivos Markdown apropriados no diretório `docs/`
+2. Teste a documentação localmente usando `microdetect docs`
+3. Certifique-se de atualizar ambas as versões de idioma conforme necessário
+4. As alterações na documentação serão incluídas no próximo build do pacote
+
+## Melhores Práticas para Documentação
+
+1. Mantenha a documentação sincronizada entre os idiomas
+2. Use links relativos entre arquivos de documentação para navegação
+3. Prefixe links de documentação internos com informações de idioma
+4. Use uma estrutura consistente entre as versões de idioma
+5. Inclua exemplos de código e capturas de tela quando apropriado
+6. Lembre-se de atualizar a documentação ao fazer alterações significativas no código
+
+## Testando o Empacotamento da Documentação
+
+Para testar se a documentação está corretamente empacotada:
+
+```bash
+# Construir o pacote
+python setup.py sdist bdist_wheel
+
+# Instalar o pacote em um ambiente de teste
+pip install --force-reinstall dist/microdetect-*.whl
+
+# Iniciar o servidor de documentação para verificar a instalação
+microdetect docs
+```
+
+Isso verificará se os arquivos de documentação estão devidamente incluídos no build e podem ser acessados através do servidor de documentação.
 
 ## Fluxo de Trabalho de Desenvolvimento
 

--- a/docs/pt/installation_guide.md
+++ b/docs/pt/installation_guide.md
@@ -231,6 +231,91 @@ cd meu_projeto
 microdetect init
 ```
 
+## Acessando a Documentação
+
+O MicroDetect agora inclui documentação abrangente empacotada com o software. Aqui está como acessá-la:
+
+## Usando o Servidor de Documentação
+
+A maneira mais fácil de visualizar a documentação é através do servidor de documentação integrado:
+
+```bash
+# Iniciar o servidor de documentação
+microdetect docs
+
+# Iniciar com um idioma específico
+microdetect docs --lang pt  # Para documentação em português
+microdetect docs --lang en  # Para documentação em inglês (padrão)
+
+# Usar uma porta diferente
+microdetect docs --port 8888
+```
+
+Este comando iniciará um servidor web local e abrirá automaticamente seu navegador para exibir a documentação.
+
+### Executando em Segundo Plano
+
+Você também pode executar o servidor de documentação em segundo plano:
+
+```bash
+# Iniciar o servidor em segundo plano
+microdetect docs --background
+
+# Verificar status do servidor
+microdetect docs --status
+
+# Parar o servidor
+microdetect docs --stop
+```
+
+## Instalando Documentação Localmente
+
+Se você preferir ter a documentação instalada em seu diretório de usuário:
+
+```bash
+# Instalar arquivos de documentação em ~/.microdetect/docs
+microdetect install-docs
+
+# Forçar reinstalação se os arquivos já existirem
+microdetect install-docs --force
+```
+
+Isso torna a documentação disponível mesmo quando offline e garante que ela seja acessível através do comando `microdetect docs`.
+
+## Acessando Arquivos de Documentação Diretamente
+
+Os arquivos de documentação estão incluídos no pacote MicroDetect e são instalados nos seguintes locais:
+
+1. Diretório do pacote: `<python_site_packages>/share/microdetect/docs/`
+2. Diretório do usuário (se instalado): `~/.microdetect/docs/`
+
+Você pode acessar os arquivos markdown diretamente nesses locais, se necessário.
+
+## Estrutura da Documentação
+
+A documentação está organizada por idioma e tópico:
+
+```
+docs/
+├── en/                          # Documentação em inglês
+│   ├── index.md                 # Ponto de entrada principal
+│   ├── installation_guide.md    # Instruções de instalação
+│   ├── ...                      # Outros tópicos
+└── pt/                          # Documentação em português
+    ├── index.md                 # Ponto de entrada principal (português)
+    ├── installation_guide.md    # Instruções de instalação (português)
+    └── ...                      # Outros tópicos
+```
+
+## Requisitos da Documentação
+
+O servidor de documentação requer os seguintes pacotes:
+
+- `markdown`: Para converter markdown para HTML
+- `pygments`: Para realce de sintaxe em blocos de código
+
+Estes serão instalados automaticamente se você usar o comando `microdetect docs` e escolher instalar as dependências quando solicitado.
+
 ## Configurar Sistema de Atualização
 
 Após a instalação, configure o sistema de atualização automática:

--- a/docs/pt/update_system.md
+++ b/docs/pt/update_system.md
@@ -125,11 +125,18 @@ O sistema de atualização opera da seguinte forma:
    - Usa pip para listar versões disponíveis
    - Extrai e compara versões usando versionamento semântico
 
-3. **Atualização**:
+3. **Fontes de Configuração**:
+   - Busca credenciais AWS em múltiplos locais nesta ordem:
+     1. Variáveis de ambiente (`AWS_CODEARTIFACT_DOMAIN`, `AWS_CODEARTIFACT_REPOSITORY`, `AWS_CODEARTIFACT_OWNER`)
+     2. Arquivo de configuração em `~/.microdetect/config.ini`
+     3. Arquivo `.env` local (para compatibilidade)
+
+4. **Processo de Atualização**:
    - Configura ambiente pip para usar o repositório AWS CodeArtifact
    - Executa a atualização preservando dependências
+   - Detecta se está executando em um ambiente Conda e ajusta conforme necessário
 
-4. **Cache de Verificação**:
+5. **Cache de Verificação**:
    - Armazena data da última verificação para não sobrecarregar
    - Verifica apenas uma vez por dia (configurável)
 

--- a/microdetect/cli.py
+++ b/microdetect/cli.py
@@ -168,17 +168,12 @@ def setup_docs_parser(subparsers):
     group.add_argument("--stop", action="store_true", help="Parar servidor em execução em background")
     group.add_argument("--status", action="store_true", help="Verificar status do servidor em background")
 
+
 def setup_install_docs_parser(subparsers):
     """Configurar o parser para o comando install-docs."""
-    parser = subparsers.add_parser(
-        "install-docs", help="Instala ou atualiza a documentação local"
-    )
-    parser.add_argument(
-        "--force", action="store_true", help="Força a reinstalação mesmo se a documentação já existir"
-    )
-    parser.add_argument(
-        "--no-interactive", dest="interactive", action="store_false", help="Modo não interativo"
-    )
+    parser = subparsers.add_parser("install-docs", help="Instala ou atualiza a documentação local")
+    parser.add_argument("--force", action="store_true", help="Força a reinstalação mesmo se a documentação já existir")
+    parser.add_argument("--no-interactive", dest="interactive", action="store_false", help="Modo não interativo")
     return parser
 
 
@@ -188,8 +183,8 @@ def handle_install_docs(args):
     Copia os arquivos da documentação para a pasta do usuário (.microdetect/docs).
     """
     import shutil
-    from pathlib import Path
     import sys
+    from pathlib import Path
 
     # Diretório home do usuário
     user_docs_dir = Path.home() / ".microdetect" / "docs"
@@ -211,6 +206,7 @@ def handle_install_docs(args):
 
     # Tentar encontrar os arquivos de documentação
     from microdetect.utils.docs_server import find_docs_dir
+
     source_docs_dir = find_docs_dir()
 
     # Verificar se a fonte é um diretório temporário (o que significa que não encontrou docs)
@@ -232,6 +228,7 @@ def handle_install_docs(args):
     except Exception as e:
         print(f"Erro ao instalar a documentação: {str(e)}")
         return
+
 
 def handle_docs(args):
     """Manipular comando de documentação."""

--- a/microdetect/cli.py
+++ b/microdetect/cli.py
@@ -168,6 +168,70 @@ def setup_docs_parser(subparsers):
     group.add_argument("--stop", action="store_true", help="Parar servidor em execução em background")
     group.add_argument("--status", action="store_true", help="Verificar status do servidor em background")
 
+def setup_install_docs_parser(subparsers):
+    """Configurar o parser para o comando install-docs."""
+    parser = subparsers.add_parser(
+        "install-docs", help="Instala ou atualiza a documentação local"
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Força a reinstalação mesmo se a documentação já existir"
+    )
+    parser.add_argument(
+        "--no-interactive", dest="interactive", action="store_false", help="Modo não interativo"
+    )
+    return parser
+
+
+def handle_install_docs(args):
+    """
+    Manipula o comando de instalação de documentação.
+    Copia os arquivos da documentação para a pasta do usuário (.microdetect/docs).
+    """
+    import shutil
+    from pathlib import Path
+    import sys
+
+    # Diretório home do usuário
+    user_docs_dir = Path.home() / ".microdetect" / "docs"
+
+    # Criar os diretórios se não existirem
+    user_docs_dir.parent.mkdir(exist_ok=True)
+
+    # Se o diretório de documentação já existir, perguntar se deseja sobrescrever
+    if user_docs_dir.exists() and not args.force:
+        if args.interactive:
+            print(f"O diretório de documentação já existe em {user_docs_dir}.")
+            response = input("Deseja sobrescrever? [s/N]: ").strip().lower()
+            if response != "s" and response != "sim":
+                print("Instalação de documentação cancelada.")
+                return
+        else:
+            print(f"O diretório de documentação já existe em {user_docs_dir}. Use --force para sobrescrever.")
+            return
+
+    # Tentar encontrar os arquivos de documentação
+    from microdetect.utils.docs_server import find_docs_dir
+    source_docs_dir = find_docs_dir()
+
+    # Verificar se a fonte é um diretório temporário (o que significa que não encontrou docs)
+    if "microdetect_docs_" in str(source_docs_dir) and "temp" in str(source_docs_dir).lower():
+        print("Não foi possível encontrar a documentação original.")
+        print("Verifique se o pacote foi instalado corretamente com os arquivos de documentação.")
+        return
+
+    try:
+        # Remover diretório existente se necessário
+        if user_docs_dir.exists():
+            shutil.rmtree(user_docs_dir)
+
+        # Copiar os arquivos de documentação
+        shutil.copytree(source_docs_dir, user_docs_dir)
+
+        print(f"Documentação instalada com sucesso em {user_docs_dir}")
+        print("Use 'microdetect docs' para visualizar a documentação.")
+    except Exception as e:
+        print(f"Erro ao instalar a documentação: {str(e)}")
+        return
 
 def handle_docs(args):
     """Manipular comando de documentação."""
@@ -601,6 +665,7 @@ def main(args: Optional[List[str]] = None):
     setup_update_parser(subparsers)
     setup_aws_parser(subparsers)
     setup_docs_parser(subparsers)
+    setup_install_docs_parser(subparsers)
 
     # Adicionar versão e ajuda
     parser.add_argument(
@@ -643,6 +708,8 @@ def main(args: Optional[List[str]] = None):
             handle_setup_aws(parsed_args)
         elif parsed_args.command == "docs":
             handle_docs(parsed_args)
+        elif parsed_args.command == "install-docs":
+            handle_install_docs(parsed_args)
         else:
             parser.print_help()
             return

--- a/microdetect/utils/docs_server.py
+++ b/microdetect/utils/docs_server.py
@@ -124,7 +124,7 @@ def find_docs_dir() -> Path:
             search_paths.append(share_dir)
 
         # Diretório específico para instalações Conda
-        if 'conda' in sys.prefix.lower() or 'miniconda' in sys.prefix.lower():
+        if "conda" in sys.prefix.lower() or "miniconda" in sys.prefix.lower():
             conda_share_dir = Path(sys.prefix) / "share/microdetect/docs"
             search_paths.append(conda_share_dir)
 
@@ -140,12 +140,13 @@ def find_docs_dir() -> Path:
     for path in search_paths:
         if path.exists() and path.is_dir():
             # Verificar se pelo menos um arquivo .md existe no caminho ou seus subdiretórios
-            md_files = list(path.glob('**/*.md'))
+            md_files = list(path.glob("**/*.md"))
             if md_files:
                 return path
 
     # Se nenhum diretório existente foi encontrado, criar um temporário
     import tempfile
+
     temp_dir = Path(tempfile.mkdtemp(prefix="microdetect_docs_"))
     temp_docs = temp_dir / "docs"
     temp_docs.mkdir(exist_ok=True)

--- a/microdetect/utils/docs_server.py
+++ b/microdetect/utils/docs_server.py
@@ -94,43 +94,58 @@ def find_docs_dir() -> Path:
     Returns:
         O caminho para o diretório docs.
     """
-    # Buscar a partir do diretório atual
+    # Lista de possíveis locais para procurar os documentos
+    search_paths = []
+
+    # 1. Buscar a partir do diretório atual
     current_dir = Path.cwd()
-    docs_dir = current_dir / "docs"
+    search_paths.append(current_dir / "docs")
 
-    if docs_dir.exists():
-        return docs_dir
+    # 2. Buscar a partir do diretório home do usuário
+    home_dir = Path.home()
+    search_paths.append(home_dir / ".microdetect" / "docs")
 
-    # Buscar a partir do diretório do pacote
+    # 3. Buscar a partir do diretório do pacote (diretório onde o módulo está instalado)
     package_dir = Path(__file__).parent.parent.parent
-    docs_dir = package_dir / "docs"
+    search_paths.append(package_dir / "docs")
 
-    if docs_dir.exists():
-        return docs_dir
-
-    # Buscar na pasta de compartilhamento de dados padrão da instalação
+    # 4. Buscar nas pastas de compartilhamento de dados padrão da instalação
     try:
         import site
+        import sys
 
+        # Diretórios do site-packages para instalações padrão
         for site_dir in site.getsitepackages():
-            share_docs_dir = Path(site_dir) / "../share/microdetect/docs"
-            if share_docs_dir.exists() and share_docs_dir.is_dir():
-                return share_docs_dir.resolve()
-    except (ImportError, AttributeError):
-        pass
+            share_docs_dir = Path(site_dir).parent / "share/microdetect/docs"
+            search_paths.append(share_docs_dir)
 
-    # Verificar também em userbase para instalações por usuário
-    try:
+            # Verificar também em share/microdetect
+            share_dir = Path(site_dir).parent / "share/microdetect"
+            search_paths.append(share_dir)
+
+        # Diretório específico para instalações Conda
+        if 'conda' in sys.prefix.lower() or 'miniconda' in sys.prefix.lower():
+            conda_share_dir = Path(sys.prefix) / "share/microdetect/docs"
+            search_paths.append(conda_share_dir)
+
+        # Verificar também em userbase para instalações por usuário
         user_base = site.USER_BASE
         share_docs_dir = Path(user_base) / "share/microdetect/docs"
-        if share_docs_dir.exists() and share_docs_dir.is_dir():
-            return share_docs_dir.resolve()
+        search_paths.append(share_docs_dir)
+
     except (ImportError, AttributeError):
         pass
 
-    # Se não encontrar, criar um diretório temporário
-    import tempfile
+    # Verificar cada caminho e retornar o primeiro existente
+    for path in search_paths:
+        if path.exists() and path.is_dir():
+            # Verificar se pelo menos um arquivo .md existe no caminho ou seus subdiretórios
+            md_files = list(path.glob('**/*.md'))
+            if md_files:
+                return path
 
+    # Se nenhum diretório existente foi encontrado, criar um temporário
+    import tempfile
     temp_dir = Path(tempfile.mkdtemp(prefix="microdetect_docs_"))
     temp_docs = temp_dir / "docs"
     temp_docs.mkdir(exist_ok=True)
@@ -144,11 +159,17 @@ def find_docs_dir() -> Path:
             if lang["dir"] == "en":
                 f.write("# MicroDetect Documentation\n\n")
                 f.write("Documentation directory not found. Please make sure the 'docs' directory exists.\n")
+                f.write("\nSearched in the following locations:\n")
+                for path in search_paths:
+                    f.write(f"- {path}\n")
             else:
                 f.write("# Documentação do MicroDetect\n\n")
                 f.write(
                     "Diretório de documentação não encontrado. Por favor, certifique-se de que o diretório 'docs' existe.\n"
                 )
+                f.write("\nBuscado nas seguintes localizações:\n")
+                for path in search_paths:
+                    f.write(f"- {path}\n")
 
     return temp_docs
 

--- a/microdetect/utils/updater.py
+++ b/microdetect/utils/updater.py
@@ -252,11 +252,11 @@ class UpdateManager:
             print(f"{ERROR}Falha ao obter token do AWS CodeArtifact{RESET}")
             return False
 
+        # Obter URL autenticada para o endpoint
+        auth_endpoint = endpoint.replace("https://", f"https://aws:{token}@")
+
         # Detectar ambiente conda
         in_conda = os.environ.get("CONDA_PREFIX") is not None
-
-        # Instalar versão mais recente
-        print(f"{INFO}Atualizando MicroDetect para versão {SUCCESS}{latest_version}{INFO}...{RESET}")
 
         # Determinar comando pip correto para o ambiente
         if in_conda:
@@ -271,19 +271,24 @@ class UpdateManager:
         else:
             pip_cmd = [sys.executable, "-m", "pip"]
 
+        # Instalar versão mais recente
+        print(f"{INFO}Atualizando MicroDetect para versão {SUCCESS}{latest_version}{INFO}...{RESET}")
+
+        # Usar a versão específica com microdetect=={latest_version}
         cmd = pip_cmd + [
             "install",
             "--upgrade",
-            "microdetect",
+            f"microdetect=={latest_version}",
             "--index-url",
-            f"{endpoint}simple/",
+            f"{auth_endpoint}simple/",
             "--extra-index-url",
             "https://pypi.org/simple",
             "--no-cache-dir",
         ]
 
+        # Configurar variáveis de ambiente para pip
         env = os.environ.copy()
-        env["PIP_INDEX_URL"] = f"{endpoint}simple/"
+        env["PIP_INDEX_URL"] = f"{auth_endpoint}simple/"
         env["PIP_EXTRA_INDEX_URL"] = "https://pypi.org/simple"
         env["TWINE_USERNAME"] = "aws"
         env["TWINE_PASSWORD"] = token

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,28 @@ def read_requirements():
 
 
 # Collect all documentation files
-doc_files = glob.glob('docs/*.md')
-doc_data_files = [('share/microdetect/docs', doc_files)]
+doc_files = glob.glob('docs/**/*.md', recursive=True)
+doc_files += glob.glob('docs/**/*.html', recursive=True)
+doc_files += glob.glob('docs/**/*.css', recursive=True)
+doc_files += glob.glob('docs/**/*.js', recursive=True)
+doc_files += glob.glob('docs/**/*.png', recursive=True)
+doc_files += glob.glob('docs/**/*.jpg', recursive=True)
+doc_files += glob.glob('docs/**/*.svg', recursive=True)
+
+# Organize doc files by directory structure
+doc_dirs = {}
+for doc_file in doc_files:
+    # Extrair diretório relativo
+    rel_dir = os.path.dirname(doc_file)
+    if rel_dir not in doc_dirs:
+        doc_dirs[rel_dir] = []
+    doc_dirs[rel_dir].append(doc_file)
+
+# Create data_files entries for each directory
+doc_data_files = []
+for rel_dir, files in doc_dirs.items():
+    install_dir = os.path.join('share/microdetect', rel_dir)
+    doc_data_files.append((install_dir, files))
 
 setup(
     name="microdetect",


### PR DESCRIPTION
# Pull Request: feat: Add command to install local documentation

## Summary of Changes
This pull request introduces a new command that allows users to install local documentation for the `microdetect` project. The following files have been modified to implement this feature:

- `MANIFEST.in`
- `microdetect/cli.py`
- `microdetect/utils/docs_server.py`
- `microdetect/utils/updater.py`
- `setup.py`

## Context
The ability to install local documentation is crucial for developers who want to have a comprehensive understanding of the `microdetect` library without relying on external resources. This feature addresses the need for offline access to documentation, allowing users to leverage available resources for troubleshooting and development.

## Testing Instructions
To verify the implementation of the new command, please follow these steps:

1. **Clone the Repository**
   ```bash
   git clone <repository-url>
   cd <repository-name>
   ```

2. **Install the Package**
   Install the package in editable mode to ensure you have the latest changes:
   ```bash
   pip install -e .
   ```

3. **Run the Documentation Installation Command**
   Execute the following command to install local documentation:
   ```bash
   microdetect docs install
   ```

4. **Verify Documentation Installation**
   After running the command, check the following:
   - The local documentation files are present in the designated directory.
   - Documentation can be served locally using the provided server command:
     ```bash
     microdetect docs serve
     ```
   - Access the documentation in your web browser by navigating to `http://localhost:8000`.

## Potential Issues and Considerations
- **Dependencies**: Ensure that all required dependencies for serving documentation are correctly listed in `setup.py` to avoid installation issues.
- **File Structure**: Review the `MANIFEST.in` modifications to confirm that all necessary documentation files are included in the package distribution.
- **Command Name**: The command name `docs install` should be intuitive for users; feedback on this naming convention is welcome.

Your feedback and suggestions are appreciated to enhance this feature further. Thank you for reviewing this pull request!